### PR TITLE
A little polishing to show FIPS feature in the 'preview' features in …

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -125,7 +126,7 @@ public class Profile {
             DEFAULT("Default"),
             DISABLED_BY_DEFAULT("Disabled by default"),
             PREVIEW("Preview"),
-            PREVIEW_DISABLED_BY_DEFAULT("Preview disabled by default"),
+            PREVIEW_DISABLED_BY_DEFAULT("Preview disabled by default"), // Preview features, which are not automatically enabled even with enabled preview profile (Needs to be enabled explicitly)
             EXPERIMENTAL("Experimental"),
             DEPRECATED("Deprecated");
 
@@ -200,8 +201,12 @@ public class Profile {
         return features.entrySet().stream().filter(e -> !e.getValue()).map(Map.Entry::getKey).collect(Collectors.toSet());
     }
 
+    /**
+     * @return all features of type "preview" or "preview_disabled_by_default"
+     */
     public Set<Feature> getPreviewFeatures() {
-        return getFeatures(Feature.Type.PREVIEW);
+        return Stream.concat(getFeatures(Feature.Type.PREVIEW).stream(), getFeatures(Feature.Type.PREVIEW_DISABLED_BY_DEFAULT).stream())
+                .collect(Collectors.toSet());
     }
 
     public Set<Feature> getExperimentalFeatures() {
@@ -260,14 +265,18 @@ public class Profile {
     }
 
     private void logUnsupportedFeatures() {
-        logUnsuportedFeatures(Feature.Type.PREVIEW, Logger.Level.INFO);
-        logUnsuportedFeatures(Feature.Type.EXPERIMENTAL, Logger.Level.WARN);
-        logUnsuportedFeatures(Feature.Type.DEPRECATED, Logger.Level.WARN);
+        logUnsuportedFeatures(Feature.Type.PREVIEW, getPreviewFeatures(), Logger.Level.INFO);
+        logUnsuportedFeatures(Feature.Type.EXPERIMENTAL, getExperimentalFeatures(), Logger.Level.WARN);
+        logUnsuportedFeatures(Feature.Type.DEPRECATED, getDeprecatedFeatures(), Logger.Level.WARN);
     }
 
-    private void logUnsuportedFeatures(Feature.Type type, Logger.Level level) {
+    private void logUnsuportedFeatures(Feature.Type type, Set<Feature> checkedFeatures, Logger.Level level) {
+        Set<Feature.Type> checkedFeatureTypes = checkedFeatures.stream()
+                .map(Feature::getType)
+                .collect(Collectors.toSet());
+
         String enabledFeaturesOfType = features.entrySet().stream()
-                .filter(e -> e.getValue() && e.getKey().getType().equals(type))
+                .filter(e -> e.getValue() && checkedFeatureTypes.contains(e.getKey().getType()))
                 .map(e -> e.getKey().getKey()).sorted().collect(Collectors.joining(", "));
 
         if (!enabledFeaturesOfType.isEmpty()) {

--- a/common/src/test/java/org/keycloak/common/ProfileTest.java
+++ b/common/src/test/java/org/keycloak/common/ProfileTest.java
@@ -76,7 +76,7 @@ public class ProfileTest {
             disabledFeatutes.add(Profile.Feature.KERBEROS);
         }
         assertEquals(profile.getDisabledFeatures(), disabledFeatutes);
-        assertEquals(profile.getPreviewFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.DECLARATIVE_USER_PROFILE, Profile.Feature.CLIENT_SECRET_ROTATION, Profile.Feature.UPDATE_EMAIL);
+        assertEquals(profile.getPreviewFeatures(), Profile.Feature.FIPS, Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.DECLARATIVE_USER_PROFILE, Profile.Feature.CLIENT_SECRET_ROTATION, Profile.Feature.UPDATE_EMAIL);
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
@@ -28,6 +28,8 @@ import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTI
 @LegacyStore
 public class FeaturesDistTest {
 
+    private static final String PREVIEW_FEATURES_EXPECTED_LOG = "Preview features enabled: admin-fine-grained-authz, client-secret-rotation, declarative-user-profile, openshift-integration, recovery-codes, scripts, token-exchange, update-email";
+
     @Test
     public void testEnableOnBuild(KeycloakDistribution dist) {
         CLIResult cliResult = dist.run(Build.NAME, "--features=preview");
@@ -45,6 +47,18 @@ public class FeaturesDistTest {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertStartedDevMode();
         assertPreviewFeaturesEnabled((CLIResult) result);
+    }
+
+    // Should enable "fips" together with all other "preview" features
+    @Test
+    @Launch({StartDev.NAME, "--features=preview,fips"})
+    public void testEnablePreviewFeaturesAndFips(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+
+        String previewFeaturesWithFipsIncluded = PREVIEW_FEATURES_EXPECTED_LOG.replace("declarative-user-profile", "declarative-user-profile, fips");
+        assertThat(result.getOutput(), CoreMatchers.allOf(
+                containsString(previewFeaturesWithFipsIncluded)));
+        cliResult.assertError("Failed to configure FIPS.");
     }
 
     @Test
@@ -87,6 +101,6 @@ public class FeaturesDistTest {
 
     private void assertPreviewFeaturesEnabled(CLIResult result) {
         assertThat(result.getOutput(), CoreMatchers.allOf(
-                containsString("Preview features enabled: admin-fine-grained-authz, client-secret-rotation, declarative-user-profile, openshift-integration, recovery-codes, scripts, token-exchange, update-email")));
+                containsString(PREVIEW_FEATURES_EXPECTED_LOG)));
     }
 }


### PR DESCRIPTION
@rmartinc I've did some testing of your PR https://github.com/keycloak/keycloak/pull/17228 and looks great!

I've just figured one small thing - when starting the server by default, the FIPS is disabled by default (which is correct), but in the admin console, it is shown as "supported" feature, which is not correct as it should be "preview". See screenshot for the details. The related issue is, that when explicitly enabled (for example by `--features=fips` or `--features=preview,fips`) it is not shown in the log at the startup in the list of "preview features".

So I've ended up with sending PR on top of your PR. If you are fine with these changes and you merge my PR (this one), your PR to keycloak main ( ttps://github.com/keycloak/keycloak/pull/17228 ) will be automatically updated :-)

![Screenshot from 2023-02-22 08-44-27](https://user-images.githubusercontent.com/1223965/220573971-326c5224-49c9-48f2-9b56-333c841ab4cb.png)
